### PR TITLE
Auto subst

### DIFF
--- a/src/latte_prelude/equal.clj
+++ b/src/latte_prelude/equal.clj
@@ -216,11 +216,14 @@ The difference with [[eq-subst]] is that we try to
 infer the property `P`."
   [def-env ctx [Px Px-type] [eq-xy eq-xy-type]]
   (let [[T x y] (decompose-equal-type def-env ctx eq-xy-type)]
+    ;; (println "find: " x)
+    ;; (println "  in: " Px-type)
     (if-let [path (pu/find-term x Px-type)]
-      (let [P (pu/build-subst-lambda Px-type T path true)]
-        [[(list #'eq-subst-prop-thm T P x y) eq-xy] Px])
+      (do ;; (println "path = " path)
+          (let [P (pu/build-subst-lambda Px-type T path true)]
+            [[(list #'eq-subst-prop-thm T P x y) eq-xy] Px]))
       (throw (ex-info "Cannot infer substitution." {:term Px-type
-                                                   :subterm x})))))
+                                                    :subterm x})))))
 
 (defthm eq-cong-prop
   "Congruence property of equality."

--- a/src/latte_prelude/utils.clj
+++ b/src/latte_prelude/utils.clj
@@ -1,0 +1,39 @@
+(ns latte-prelude.utils
+  (:require [latte-kernel.syntax :as stx])
+)
+
+(defn find-term
+  "Finds term `t` within term `u` recursively, constructing
+  the `path` to the first occurrence. The lookup is simply wrt.
+  structural equality."
+  ([t u] (find-term t u []))
+
+  ([t u path]
+   (cond
+     ;; found !
+     (= t u) path
+
+     (stx/binder? u)
+     (let [[_ _ body] u]
+       (find-term t body (conj path 2))) ;; element at index 2 in the term u
+
+     (stx/app? u)
+     (let [[u1 u2] u]
+       (or (find-term t u1 (conj path 0))
+           (find-term t u2 (conj path 1))))
+
+     (stx/ref? u)
+     (let [nbargs (dec (count u))]
+       (loop [k 1]
+         (if (<= k nbargs)
+           (or (find-term t (nth u k) (conj path k))
+               (recur (inc k)))
+           false)))
+
+     
+     ;; all the other cases fail
+     :else false)))
+
+
+
+       

--- a/src/latte_prelude/utils.clj
+++ b/src/latte_prelude/utils.clj
@@ -76,10 +76,10 @@ substituted term."
     (stx/ref? u)
     (let [[dname & args] u
           vargs (vec args)
-          before-args (subvec 0 (dec (first path)))
-          after-args (subvec (inc (first path)))]
-      (list dname (concat before-args
-                          (body-build tvar (rest path) (nth vargs (first path)))
+          before-args (subvec vargs 0 (dec (first path)))
+          after-args (subvec vargs (first path))]
+      (cons dname (concat before-args
+                          (list (body-build tvar (rest path) (nth vargs (first path))))
                           after-args)))
 
     :else u))

--- a/src/latte_prelude/utils.clj
+++ b/src/latte_prelude/utils.clj
@@ -6,27 +6,35 @@
   "Finds term `t` within term `u` recursively, constructing
   the `path` to the first occurrence. The lookup is simply wrt.
   structural equality."
-  ([t u] (find-term t u []))
+  ([t u] (find-term t u [] #{}))
 
-  ([t u path]
+  ([t u path bound]
    (cond
-     ;; found !
-     (= t u) path
+     ;; first, we try with structural equality
+     (and (not (bound t))
+          (= t u)) 
+     path
+
+     ;; let's try with alpha-norm
+     (and (not (bound t))
+          (stx/alpha-eq? t u))
+     path
 
      (stx/binder? u)
-     (let [[_ _ body] u]
-       (find-term t body (conj path 2))) ;; element at index 2 in the term u
+     (let [[_ [x ty] body] u]
+       (or (find-term t ty (conj path 1) bound)
+           (find-term t body (conj path 2) (conj bound x))))
 
      (stx/app? u)
      (let [[u1 u2] u]
-       (or (find-term t u1 (conj path 0))
-           (find-term t u2 (conj path 1))))
+       (or (find-term t u1 (conj path 0) bound)
+           (find-term t u2 (conj path 1) bound)))
 
      (stx/ref? u)
      (let [nbargs (dec (count u))]
        (loop [k 1]
          (if (<= k nbargs)
-           (or (find-term t (nth u k) (conj path k))
+           (or (find-term t (nth u k) (conj path k) bound)
                (recur (inc k)))
            false)))
 
@@ -34,6 +42,47 @@
      ;; all the other cases fail
      :else false)))
 
+(declare body-build)
 
+(defn build-subst-lambda 
+  "Builds a lambda for substitutions of a subterm `$` within `u`
+according to its `path`. The parameter `ty` is the type of the
+substituted term."  
+  [u ty path with-gensym]
+  (let [$ (if with-gensym
+            (gensym "$")
+            '$)]
+    (list 'λ [$ ty] (body-build $ path u)))) 
+  
+(defn body-build
+  "This had to be a function with such a name"
+  [tvar path u]
+  (cond 
+    ;; at the end of the path ...
+    (= path []) tvar
+
+    (stx/binder? u)
+    (let [[b [x ty] body] u]
+      (if (= (first path) 1)
+        (list b [x (body-build tvar (rest path) ty)] body) 
+        (list b [x ty] (body-build tvar (rest path) body))))
+
+    (stx/app? u)
+    (let [[u1 u2] u]
+      (if (= (first path) 0)
+        [(body-build tvar (rest path) u1) u2]
+        [u1 (body-build tvar (rest path) u2)]))
+
+    (stx/ref? u)
+    (let [[dname & args] u
+          vargs (vec args)
+          before-args (subvec 0 (dec (first path)))
+          after-args (subvec (inc (first path)))]
+      (list dname (concat before-args
+                          (body-build tvar (rest path) (nth vargs (first path)))
+                          after-args)))
+
+    :else u))
+    
 
        

--- a/test/latte_prelude/subst_test.clj
+++ b/test/latte_prelude/subst_test.clj
@@ -55,6 +55,10 @@
   (is (= (find-term (parse '(lambda [x T] x))
                     (parse '(lambda [f (==> T T T)] [f (lambda [z T] x)])))
          false))
+
+  (is (= (find-term (parse 'x)
+                    (parse (list #'latte-prelude.equal/equal '(f x) '(f x))))
+         [1 1]))
      
   )
 
@@ -72,6 +76,9 @@
                              (parse '(==> T T)) [2 1] false)
          '(λ [$ (Π [⇧ T] T)] (λ [f (Π [⇧ T] (Π [⇧ T] T))] [f $]))))
          
+  (is (= (build-subst-lambda (parse (list #'latte-prelude.equal/equal '(f x) '(f x))) 'T [1 1] false)
+         (list 'λ ['$ 'T] (list #'latte-prelude.equal/equal '[f $] '[f x]))))
+
   )
 
 ;; XXX: why `example` cannot by used in a `deftest`
@@ -88,6 +95,19 @@
            (have <a> _ :by (latte-prelude.equal/eq-subst (lambda [$ T]
                                                 (latte-prelude.equal/equal (f x) (f $)))
                                         Heq (latte-prelude.equal/eq-refl (f x)))))
+         (qed <a>))
+
+       [:checked :example]))
+
+(is (=
+
+       (example [[T :type] [U :type] [x T] [y T] [f (==> T U)]]
+           (==> (equal x y)
+                (equal (f y) (f x)))
+         ;; proof
+         (assume [Heq _]
+           (have <a> _ :by (latte-prelude.equal/subst (latte-prelude.equal/eq-refl (f x)) 
+                                                      Heq)))
          (qed <a>))
 
        [:checked :example]))

--- a/test/latte_prelude/subst_test.clj
+++ b/test/latte_prelude/subst_test.clj
@@ -20,45 +20,55 @@
 (deftest test-find-term-simple
   (is (= (find-term (parse 'x)
                     (parse 'x))
-         []))
+         [:ok []]))
 
   (is (= (find-term (parse 'x)
                     (parse 'y))
-         false))
+         [:ko 1]))
 
   (is (= (find-term (parse 'x)
                     (parse '(lambda [y T] y)))
-         false))
+         [:ko 1]))
 
   (is (= (find-term (parse 'T)
                     (parse '(lambda [y T] x)))
-         [1]))
+         [:ok [1]]))
 
   (is (= (find-term (parse 'x)
                     (parse '(lambda [y T] x)))
-         [2]))
+         [:ok [2]]))
 
   ;; A special case, if we are looking for a variable
   ;; that gets bound in the term u (arguably rare case)
   (is (= (find-term (parse 'x)
                     (parse '(lambda [x T] x)))
-         false))
+         [:ko 1]))
+
+  ;; A similar case
+  (is (= (find-term (parse 'x)
+                    (parse '(lambda [x T] (f x))))
+         [:ko 1]))
 
   (is (= (find-term (parse '(lambda [x T] x))
                     (parse '(lambda [f (==> T T T)] [f (lambda [x T] x)])))
-         [2 1]))
+         [:ok [2 1]]))
 
   (is (= (find-term (parse '(lambda [x T] x))
                     (parse '(lambda [f (==> T T T)] [f (lambda [z T] z)])))
-         [2 1]))
+         [:ok [2 1]]))
 
   (is (= (find-term (parse '(lambda [x T] x))
                     (parse '(lambda [f (==> T T T)] [f (lambda [z T] x)])))
-         false))
+         [:ko 1]))
 
   (is (= (find-term (parse 'x)
                     (parse (list #'latte-prelude.equal/equal '(f x) '(f x))))
-         [1 1]))
+         [:ok [1 1]]))
+
+  (is (= (find-term (parse 'x)
+                    (parse (list #'latte-prelude.equal/equal '(f x) '(f x)))
+                    2) ;; we ask for the 2-nd occurrence
+         [:ok [2 1]]))
      
   )
 
@@ -79,36 +89,56 @@
   (is (= (build-subst-lambda (parse (list #'latte-prelude.equal/equal '(f x) '(f x))) 'T [1 1] false)
          (list 'λ ['$ 'T] (list #'latte-prelude.equal/equal '[f $] '[f x]))))
 
+  (is (= (build-subst-lambda (parse (list #'latte-prelude.equal/equal '(f x) '(f x))) 'T [2 1] false)
+         (list 'λ ['$ 'T] (list #'latte-prelude.equal/equal '[f x] '[f $]))))
   )
 
 ;; XXX: why `example` cannot by used in a `deftest`
 ;; if the full namespace is not given ?
-(deftest test-subst-ex1
+(deftest test-rewrite-simple
 
-  (is (=
+  (is (= (example [[T :type] [U :type] [x T] [y T] [f (==> T U)]]
+             (==> (equal x y)
+                  (equal (f x) (f y)))
+           ;; proof
+           (assume [Heq _]
+             (have <a> _ :by (latte-prelude.equal/eq-subst (lambda [$ T]
+                                                                   (latte-prelude.equal/equal (f x) (f $)))
+                                                           Heq (latte-prelude.equal/eq-refl (f x)))))
+           (qed <a>))
+         
+         [:checked :example]))
+  
+  (is (= (example [[T :type] [U :type] [x T] [y T] [f (==> T U)]]
+             (==> (equal x y)
+                  (equal (f y) (f x)))
+           ;; proof
+           (assume [Heq _]
+             (have <a> _ :by (latte-prelude.equal/rewrite (latte-prelude.equal/eq-refl (f x)) 
+                                                          Heq)))
+           (qed <a>))
+         
+         [:checked :example]))
 
-       (example [[T :type] [U :type] [x T] [y T] [f (==> T U)]]
-           (==> (equal x y)
-                (equal (f x) (f y)))
-         ;; proof
-         (assume [Heq _]
-           (have <a> _ :by (latte-prelude.equal/eq-subst (lambda [$ T]
-                                                (latte-prelude.equal/equal (f x) (f $)))
-                                        Heq (latte-prelude.equal/eq-refl (f x)))))
-         (qed <a>))
+  (is (= (example [[T :type] [U :type] [x T] [y T] [f (==> T U)]]
+             (==> (equal x y)
+                  (equal (f y) (f x)))
+           ;; proof
+           (assume [Heq _]
+             (have <a> _ :by (latte-prelude.equal/nrewrite 1 (latte-prelude.equal/eq-refl (f x)) 
+                                                           Heq)))
+           (qed <a>))
+         
+         [:checked :example]))
 
-       [:checked :example]))
-
-(is (=
-
-       (example [[T :type] [U :type] [x T] [y T] [f (==> T U)]]
-           (==> (equal x y)
-                (equal (f y) (f x)))
-         ;; proof
-         (assume [Heq _]
-           (have <a> _ :by (latte-prelude.equal/subst (latte-prelude.equal/eq-refl (f x)) 
-                                                      Heq)))
-         (qed <a>))
-
-       [:checked :example]))
-)
+  (is (= (example [[T :type] [U :type] [x T] [y T] [f (==> T U)]]
+             (==> (equal x y)
+                  (equal (f x) (f y)))
+           ;; proof
+           (assume [Heq _]
+             (have <a> _ :by (latte-prelude.equal/nrewrite 2 (latte-prelude.equal/eq-refl (f x)) 
+                                                           Heq)))
+           (qed <a>))
+         
+         [:checked :example]))
+  )

--- a/test/latte_prelude/subst_test.clj
+++ b/test/latte_prelude/subst_test.clj
@@ -1,0 +1,63 @@
+(ns latte-prelude.subst-test
+  (:require [clojure.test :refer :all]
+
+            [latte-kernel.presyntax :as pstx :refer [parse-term]]
+            [latte-kernel.defenv :as defenv]
+            [latte.core :as latte :refer [example assume have qed]]
+
+            [latte-prelude.utils :refer [find-term]]
+            [latte-prelude.equal :as eq :refer [equal]])
+  )
+
+(defn parse
+  ([t] (parse {} t))
+  ([env t]
+   (let [[ok t'] (parse-term (defenv/mkenv env) t)]
+     (if (= ok :ok)
+       t'
+       (throw (ex-info "Parse fail" {:cause t'}))))))
+
+(deftest test-find-term-simple
+  (is (= (find-term (parse 'x)
+                    (parse 'x))
+         []))
+
+  (is (= (find-term (parse 'x)
+                    (parse 'y))
+         false))
+
+  (is (= (find-term (parse 'x)
+                    (parse '(lambda [y T] y)))
+         false))
+
+  (is (= (find-term (parse 'x)
+                    (parse '(lambda [y T] x)))
+         [2]))
+
+  ;; XXX: the following is strange, because there's a name
+  ;; capture, however we'll progress one step at a time
+  (is (= (find-term (parse 'x)
+                    (parse '(lambda [x T] x)))
+         [2]))
+)
+
+;; XXX: why `example` cannot by used in a `deftest` ?
+;; (deftest test-subst-ex1
+
+;;   (is (=
+
+;;        (example [[T :type] [U :type] [x T] [y T] [f (==> T U)]]
+;;            (==> (equal x y)
+;;                 (equal (f x) (f y)))
+;;          ;; proof
+;;          (assume [Heq _]
+;;            (have <a> _ :by (eq/eq-subst (lambda [$ T]
+;;                                                 (equal (f x) (f $)))
+;;                                         Heq (eq/eq-refl (f x)))))
+;;          (qed <a>))
+
+;;        [:checked :example]))
+;; )
+           
+
+

--- a/test/latte_prelude/subst_test.clj
+++ b/test/latte_prelude/subst_test.clj
@@ -74,23 +74,21 @@
          
   )
 
-;; XXX: why `example` cannot by used in a `deftest` ?
-;; (deftest test-subst-ex1
+;; XXX: why `example` cannot by used in a `deftest`
+;; if the full namespace is not given ?
+(deftest test-subst-ex1
 
-;;   (is (=
+  (is (=
 
-;;        (example [[T :type] [U :type] [x T] [y T] [f (==> T U)]]
-;;            (==> (equal x y)
-;;                 (equal (f x) (f y)))
-;;          ;; proof
-;;          (assume [Heq _]
-;;            (have <a> _ :by (eq/eq-subst (lambda [$ T]
-;;                                                 (equal (f x) (f $)))
-;;                                         Heq (eq/eq-refl (f x)))))
-;;          (qed <a>))
+       (example [[T :type] [U :type] [x T] [y T] [f (==> T U)]]
+           (==> (equal x y)
+                (equal (f x) (f y)))
+         ;; proof
+         (assume [Heq _]
+           (have <a> _ :by (latte-prelude.equal/eq-subst (lambda [$ T]
+                                                (latte-prelude.equal/equal (f x) (f $)))
+                                        Heq (latte-prelude.equal/eq-refl (f x)))))
+         (qed <a>))
 
-;;        [:checked :example]))
-;; )
-           
-
-
+       [:checked :example]))
+)


### PR DESCRIPTION
New proof methods `rewrite` and `nrewrite`  that allows to automate substitution proofs, as suggest by issue #7 